### PR TITLE
Optimizing build + exposing scorer

### DIFF
--- a/native_client/BUILD
+++ b/native_client/BUILD
@@ -350,10 +350,7 @@ cc_binary(
         "wasm/bindings.cc",
     ],
     deps = [":decoder", ":coqui_stt_bundle"],
-    copts = select({
-        "//tensorflow:windows": ["/std:c++14"],
-        "//conditions:default": ["-std=c++14", "-fexceptions", "-fwrapv", "-pthread"],
-    }),
+    copts = ["-std=c++14", "-fno-exceptions", "-fwrapv", "-pthread"],
     linkopts = DECODER_LINKOPTS + [
         "--bind",
         "-s WASM=1",
@@ -363,7 +360,7 @@ cc_binary(
         # Allow to grow memory allocation when needed (for example for loading models).
         "-sALLOW_MEMORY_GROWTH",
         # test
-        "-sPTHREAD_POOL_SIZE=8",
+        "-sPTHREAD_POOL_SIZE=4",
         # This is a library, so no 'main' is expected.
         "--no-entry"
     ],

--- a/native_client/wasm/test.html
+++ b/native_client/wasm/test.html
@@ -29,12 +29,27 @@
                     sampleRate: modelSampleRate
                 });
 
+                const scorerInput = document.getElementById("scorerpicker");
+                scorerInput.addEventListener("change", (e) => loadScorer(e.target.files[0]), false);
+                scorerInput.disabled = false;
+
                 // Now that a model is available, enable opening the audio file.
                 const audioInput = document.getElementById("audiopicker");
                 audioInput.addEventListener("change", (e) => processAudio(e.target.files[0]), false);
                 audioInput.disabled = false;
             };
             reader.readAsArrayBuffer(modelFiles[0]);
+        };
+
+        function loadScorer(scorerFile) {
+            console.log(`Loading scorer`, scorerFile);
+
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const result = activeModel.enableExternalScorer(new Uint8Array(reader.result));
+                console.log(`Loading complete: ${result}`);
+            };
+            reader.readAsArrayBuffer(scorerFile);
         };
 
         function processAudio(audioFile) {
@@ -50,8 +65,15 @@
                     const toPass = new Module.VectorShort();
                     processedAudio.forEach(e => toPass.push_back(e));
 
-                    console.debug(processedAudio, toPass);
-                    console.log(`Transcription: ${activeModel.speechToText(toPass)}`);
+                    const now = Date.now();
+                    const result = activeModel.speechToText(toPass);
+                    const elapsedSeconds = (Date.now() - now)/1000;
+                    
+                    document.getElementById("result").textContent = result;
+                    console.log(`Transcription: ${result}`);
+                    
+                    document.getElementById("elapsedSeconds").textContent = elapsedSeconds;
+                    console.log(`Elapsed: ${elapsedSeconds} seconds`)
                 });
             };
             reader.readAsArrayBuffer(audioFile);
@@ -67,15 +89,30 @@
             }
         };
     </script>
-    <script src="stt_wasm.js"></script>
+    <script src="build/stt_wasm.js"></script>
     <div>
         <label for="modelpicker">Coqui TFLite Model file:</label>
-        <input type="file" name="modelpicker" id="modelpicker" disabled>
+        <input type="file" name="modelpicker" id="modelpicker">
+
+        <br />
+
+        <label for="scorerpicker">Scorer (optional):</label>
+        <input type="file" name="scorerpicker" id="scorerpicker" disabled>
 
         <br />
 
         <label for="audiopicker">Audio sample file:</label>
         <input type="file" name="audiopicker" id="audiopicker" disabled>
+
+        <br />
+
+        <label for="result">Transcription:</label>
+        <span id="result"></span>
+
+        <br />
+
+        <label for="elapsedSeconds">Elapsed time (s):</label>
+        <span id="elapsedSeconds"></span>
     </div>
   </body>
 </html>


### PR DESCRIPTION
I exposed the enableExternalScorer function and tested it, it works great!
As for the number of PTHREADS, I reached the conclusion that it is not worth having more than 4 as that is the number of threads used by coqui stt (hardcoded [here](https://github.com/Dexterp37/STT/blob/main/native_client/tflitemodelstate.cc#L200))

As for the logging in bindings.cc, I think we should eventually remove it but have left it for now as it was useful for debugging.