### PR TITLE
Add streaming demo with microphone input

### DIFF
--- a/native_client/wasm/audiobuffer-to-wav/LICENSE.md
+++ b/native_client/wasm/audiobuffer-to-wav/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+Copyright (c) 2015 Jam3
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/native_client/wasm/audiobuffer-to-wav/index.js
+++ b/native_client/wasm/audiobuffer-to-wav/index.js
@@ -1,0 +1,93 @@
+function audioBufferToWav (buffer, opt) {
+  opt = opt || {}
+
+  var numChannels = buffer.numberOfChannels
+  var sampleRate = buffer.sampleRate
+  var format = opt.float32 ? 3 : 1
+  var bitDepth = format === 3 ? 32 : 16
+
+  var result
+  if (numChannels === 2) {
+    result = interleave(buffer.getChannelData(0), buffer.getChannelData(1))
+  } else {
+    result = buffer.getChannelData(0)
+  }
+
+  return encodeWAV(result, format, sampleRate, numChannels, bitDepth)
+}
+
+function encodeWAV (samples, format, sampleRate, numChannels, bitDepth) {
+  var bytesPerSample = bitDepth / 8
+  var blockAlign = numChannels * bytesPerSample
+
+  var buffer = new ArrayBuffer(44 + samples.length * bytesPerSample)
+  var view = new DataView(buffer)
+
+  /* RIFF identifier */
+  writeString(view, 0, 'RIFF')
+  /* RIFF chunk length */
+  view.setUint32(4, 36 + samples.length * bytesPerSample, true)
+  /* RIFF type */
+  writeString(view, 8, 'WAVE')
+  /* format chunk identifier */
+  writeString(view, 12, 'fmt ')
+  /* format chunk length */
+  view.setUint32(16, 16, true)
+  /* sample format (raw) */
+  view.setUint16(20, format, true)
+  /* channel count */
+  view.setUint16(22, numChannels, true)
+  /* sample rate */
+  view.setUint32(24, sampleRate, true)
+  /* byte rate (sample rate * block align) */
+  view.setUint32(28, sampleRate * blockAlign, true)
+  /* block align (channel count * bytes per sample) */
+  view.setUint16(32, blockAlign, true)
+  /* bits per sample */
+  view.setUint16(34, bitDepth, true)
+  /* data chunk identifier */
+  writeString(view, 36, 'data')
+  /* data chunk length */
+  view.setUint32(40, samples.length * bytesPerSample, true)
+  if (format === 1) { // Raw PCM
+    floatTo16BitPCM(view, 44, samples)
+  } else {
+    writeFloat32(view, 44, samples)
+  }
+
+  return buffer
+}
+
+function interleave (inputL, inputR) {
+  var length = inputL.length + inputR.length
+  var result = new Float32Array(length)
+
+  var index = 0
+  var inputIndex = 0
+
+  while (index < length) {
+    result[index++] = inputL[inputIndex]
+    result[index++] = inputR[inputIndex]
+    inputIndex++
+  }
+  return result
+}
+
+function writeFloat32 (output, offset, input) {
+  for (var i = 0; i < input.length; i++, offset += 4) {
+    output.setFloat32(offset, input[i], true)
+  }
+}
+
+function floatTo16BitPCM (output, offset, input) {
+  for (var i = 0; i < input.length; i++, offset += 2) {
+    var s = Math.max(-1, Math.min(1, input[i]))
+    output.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true)
+  }
+}
+
+function writeString (view, offset, string) {
+  for (var i = 0; i < string.length; i++) {
+    view.setUint8(offset + i, string.charCodeAt(i))
+  }
+}

--- a/native_client/wasm/stt-audio-processor.js
+++ b/native_client/wasm/stt-audio-processor.js
@@ -1,0 +1,52 @@
+/**
+ * According to the docs, this should be in a separate js file
+ * https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletProcessor
+ *
+ * @extends AudioWorkletProcessor
+ */
+
+ class STTAudioProcessor extends AudioWorkletProcessor {
+    BUFFER_SIZE = 8192;
+    SAMPLE_SIZE = 128;
+
+    constructor() {
+      super();
+      this._buffer = new Int16Array(this.BUFFER_SIZE);
+      this._numSamples = 0;
+      this._maxSamples = this.BUFFER_SIZE/this.SAMPLE_SIZE;
+    }
+
+    converFloat32ToInt16(buffer) {
+      return Int16Array.from(buffer, x => x * 32767);
+    }
+
+    /**
+     * Process captured channel data and send it to the main thread via message.
+     * AudioWorklet captures 128-byte samples, so we accumulate them and send a 8192-byte buffer. 
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletProcessor/process
+     */
+    process(inputs) {       
+      if (!inputs[0] || !inputs[0][0]) {
+        return true;
+      }
+      
+      const channelData = this.converFloat32ToInt16(inputs[0][0]);
+
+      if (this._numSamples < this._maxSamples - 1) {
+        // accumulate input data to the buffer.
+        this._buffer.set(channelData, this._numSamples*this.SAMPLE_SIZE);
+        this._numSamples += 1;
+      } else {
+        // final sample, accumulate then send it to the main thread.
+        this._buffer.set(channelData, this._numSamples*this.SAMPLE_SIZE);
+        this._numSamples = 0;
+
+        this.port.postMessage(this._buffer);
+      }
+      
+      return true;  
+    }
+}
+  
+registerProcessor('stt-audio-processor', STTAudioProcessor);

--- a/native_client/wasm/test.html
+++ b/native_client/wasm/test.html
@@ -7,11 +7,13 @@
   <body>
     <script src="audiobuffer-to-wav/index.js"></script>
     <script>
+        var ENABLE_AUDIO_DOWNLOAD = false;
+
         var activeModel;
         var activeModelStream;
         var activeRecordingData;
         var audioContext;
-        var audioProcessor;
+        var audioWorkletNode;
         var mediaStream;
         var mediaStreamSource;
 
@@ -19,40 +21,6 @@
         function converFloat32ToInt16(buffer) {
             return Int16Array.from(buffer, x => x * 32767);
         }
-
-        function createAudioProcessor() {
-            audioProcessor = audioContext.createScriptProcessor(8192, 1, 1);
-                                    
-            audioProcessor.onaudioprocess = (event) => {
-                // Decode intermediate results on each sample 
-                const transcription = activeModelStream.intermediateDecode();
-                document.getElementById("result").textContent = transcription;
-                console.log(`Intermediate transcription: ${transcription}`);
-                
-                // Accumulate audio data by allocating a new buffer
-                var monoAudioData = event.inputBuffer.getChannelData(0);
-                const mergedData = new Float32Array(activeRecordingData.length + monoAudioData.length);
-                mergedData.set(activeRecordingData);
-                mergedData.set(monoAudioData, activeRecordingData.length);
-                activeRecordingData = mergedData;
-        
-                const processedAudio = converFloat32ToInt16(monoAudioData);
-                // Convert the `processedAudio` to something that can be passed
-                // across the WASM boundaries.
-                const toPass = new Module.VectorShort();
-                processedAudio.forEach(e => toPass.push_back(e));
-
-                // Feed the processed audio to the model stream
-                activeModelStream.feedAudioContent(toPass);
-            };
-            
-            audioProcessor.shutdown = () => {
-                audioProcessor.disconnect();
-                audioProcessor.onaudioprocess = null;
-            };
-            
-            audioProcessor.connect(audioContext.destination);            
-        };
 
         function loadModel(modelFiles) {
             console.log(`Loading models`, modelFiles);
@@ -69,7 +37,7 @@
 
                 // Now that a model is available, enable audio input selection (file or microphone).
                 const audioFileInput = document.getElementById("audiopicker");
-                audioFileInput.addEventListener("change", (e) => processAudio(e.target.files[0]), false);
+                audioFileInput.addEventListener("change", (e) => processAudioFromFile(e.target.files[0]), false);
                 audioFileInput.disabled = false;
 
                 const downloadAudioLink = document.getElementById("downloadAudioLink");
@@ -78,14 +46,14 @@
                 
                 startRecordingButton.disabled = false;
                 startRecordingButton.addEventListener("click", (e) => {
-                    downloadAudioLink.style.display = "none";
+                    if (ENABLE_AUDIO_DOWNLOAD) downloadAudioLink.style.display = "none";
                     startRecordingButton.disabled = true;
                     stopRecordingButton.disabled = false;
 
                     startRecording();
                 }, false);
                 stopRecordingButton.addEventListener("click", (e) => {
-                    downloadAudioLink.style.display = "block";
+                    if (ENABLE_AUDIO_DOWNLOAD) downloadAudioLink.style.display = "block";
                     startRecordingButton.disabled = false;
                     stopRecordingButton.disabled = true;
                     
@@ -106,7 +74,39 @@
             reader.readAsArrayBuffer(scorerFile);
         };
 
-        function startRecording() {
+        function onAudioProcess(leftChannelData) {
+            // Decode intermediate results on each sample 
+            const transcription = activeModelStream.intermediateDecode();
+            document.getElementById("result").textContent = transcription;
+            console.log(`Intermediate transcription: ${transcription}`);
+            
+            // Accumulate audio data by allocating a new buffer
+            if (ENABLE_AUDIO_DOWNLOAD) {
+                const floatleftChannelData = Float32Array.from(leftChannelData, x => x/32767);
+                const mergedData = new Float32Array(activeRecordingData.length + floatleftChannelData.length);
+                mergedData.set(activeRecordingData);
+                mergedData.set(floatleftChannelData, activeRecordingData.length);
+                activeRecordingData = mergedData;
+            }
+    
+            // Convert the `leftChannelData` to something that can be passed
+            // across the WASM boundaries.
+            const toPass = new Module.VectorShort();
+            leftChannelData.forEach(e => toPass.push_back(e));
+
+            // Feed the processed audio to the model stream
+            activeModelStream.feedAudioContent(toPass);
+        }
+        
+        async function setupAudioWorklet() {
+            await audioContext.audioWorklet.addModule('stt-audio-processor.js');
+            audioWorkletNode = new AudioWorkletNode(audioContext, 'stt-audio-processor');
+            audioWorkletNode.port.onmessage = (event) => {
+                onAudioProcess(event.data);
+            };
+        }
+
+        async function startRecording() {
             activeModelStream = activeModel.createStream();
             
             const modelSampleRate = activeModel.getSampleRate();
@@ -115,14 +115,17 @@
                 // Use the model's sample rate so that the decoder will resample for us.
                 sampleRate: modelSampleRate
             });
+
+            await setupAudioWorklet();
             
-            const onSuccess = (stream) => {
+            const onSuccess = async (stream) => {
                 console.log('started recording');
                 activeRecordingData = [];
                 mediaStream = stream;
                 mediaStreamSource = audioContext.createMediaStreamSource(mediaStream);
-                createAudioProcessor();
-                mediaStreamSource.connect(audioProcessor);
+                
+                audioWorkletNode.connect(audioContext.destination);
+                mediaStreamSource.connect(audioWorkletNode);
             };
             
             const onError = (error) => {
@@ -146,36 +149,37 @@
         };
 	
         function stopRecording() {
+            // Free audio worklet resources and message listener
+            audioWorkletNode.port.postMessage({release: true});
+            audioWorkletNode.port.onmessage = null;
+            audioWorkletNode.port.close();
+            audioWorkletNode = null;
+    
+            // Free stream and audioContext resources
+            mediaStream.getTracks()[0].stop();
+            mediaStreamSource.disconnect();
+            audioContext.close();
+    
+            // Get the final transcription results
             const transcription = activeModelStream.finishStream();
             document.getElementById("result").textContent = transcription;
             console.log(`Transcription: ${transcription}`);
 
-            const modelSampleRate = activeModel.getSampleRate();
-            // TODO: handle different bit widths and more than one channel?
-            var audioUrl = URL.createObjectURL(
-                new Blob([encodeWAV(activeRecordingData, 1, modelSampleRate, 1, 16)], 
-                {type: "audio/wav"})
-            );
-            var downloadAudioEl = document.getElementById("downloadAudioLink");
-            downloadAudioEl.href = audioUrl;
+            if (ENABLE_AUDIO_DOWNLOAD) {
+                const modelSampleRate = activeModel.getSampleRate();
+                // TODO: handle different bit widths and more than one channel?
+                var audioUrl = URL.createObjectURL(
+                    new Blob([encodeWAV(activeRecordingData, 1, modelSampleRate, 1, 16)], 
+                    {type: "audio/wav"})
+                );
+                var downloadAudioEl = document.getElementById("downloadAudioLink");
+                downloadAudioEl.href = audioUrl;
+            }
 
             activeModelStream = null;
-
-            if (mediaStream) {
-                mediaStream.getTracks()[0].stop();
-            }
-            if (mediaStreamSource) {
-                mediaStreamSource.disconnect();
-            }
-            if (audioProcessor) {
-                audioProcessor.shutdown();
-            }
-            if (audioContext) {
-                audioContext.close();
-            }
         };
 
-        function processAudio(audioFile) {
+        function processAudioFromFile(audioFile) {
             console.log(`Loading audio file`, audioFile);
             
             const modelSampleRate = activeModel.getSampleRate();

--- a/native_client/wasm/test.html
+++ b/native_client/wasm/test.html
@@ -5,14 +5,54 @@
     <title>WASM Sample</title>
   </head>
   <body>
+    <script src="audiobuffer-to-wav/index.js"></script>
     <script>
         var activeModel;
+        var activeModelStream;
+        var activeRecordingData;
         var audioContext;
+        var audioProcessor;
+        var mediaStream;
+        var mediaStreamSource;
 
         // https://stackoverflow.com/q/33738873/261698
         function converFloat32ToInt16(buffer) {
             return Int16Array.from(buffer, x => x * 32767);
         }
+
+        function createAudioProcessor() {
+            audioProcessor = audioContext.createScriptProcessor(8192, 1, 1);
+                                    
+            audioProcessor.onaudioprocess = (event) => {
+                // Decode intermediate results on each sample 
+                const transcription = activeModelStream.intermediateDecode();
+                document.getElementById("result").textContent = transcription;
+                console.log(`Intermediate transcription: ${transcription}`);
+                
+                // Accumulate audio data by allocating a new buffer
+                var monoAudioData = event.inputBuffer.getChannelData(0);
+                const mergedData = new Float32Array(activeRecordingData.length + monoAudioData.length);
+                mergedData.set(activeRecordingData);
+                mergedData.set(monoAudioData, activeRecordingData.length);
+                activeRecordingData = mergedData;
+        
+                const processedAudio = converFloat32ToInt16(monoAudioData);
+                // Convert the `processedAudio` to something that can be passed
+                // across the WASM boundaries.
+                const toPass = new Module.VectorShort();
+                processedAudio.forEach(e => toPass.push_back(e));
+
+                // Feed the processed audio to the model stream
+                activeModelStream.feedAudioContent(toPass);
+            };
+            
+            audioProcessor.shutdown = () => {
+                audioProcessor.disconnect();
+                audioProcessor.onaudioprocess = null;
+            };
+            
+            audioProcessor.connect(audioContext.destination);            
+        };
 
         function loadModel(modelFiles) {
             console.log(`Loading models`, modelFiles);
@@ -23,20 +63,34 @@
                 const modelSampleRate = activeModel.getSampleRate();
                 console.log(`Model sample rate: ${modelSampleRate}`);
 
-                // Create an audio context for future processing.
-                audioContext = new AudioContext({
-                    // Use the model's sample rate so that the decoder will resample for us.
-                    sampleRate: modelSampleRate
-                });
-
                 const scorerInput = document.getElementById("scorerpicker");
                 scorerInput.addEventListener("change", (e) => loadScorer(e.target.files[0]), false);
                 scorerInput.disabled = false;
 
-                // Now that a model is available, enable opening the audio file.
-                const audioInput = document.getElementById("audiopicker");
-                audioInput.addEventListener("change", (e) => processAudio(e.target.files[0]), false);
-                audioInput.disabled = false;
+                // Now that a model is available, enable audio input selection (file or microphone).
+                const audioFileInput = document.getElementById("audiopicker");
+                audioFileInput.addEventListener("change", (e) => processAudio(e.target.files[0]), false);
+                audioFileInput.disabled = false;
+
+                const downloadAudioLink = document.getElementById("downloadAudioLink");
+                const startRecordingButton = document.getElementById("startRecordingButton");
+                const stopRecordingButton = document.getElementById("stopRecordingButton");
+                
+                startRecordingButton.disabled = false;
+                startRecordingButton.addEventListener("click", (e) => {
+                    downloadAudioLink.style.display = "none";
+                    startRecordingButton.disabled = true;
+                    stopRecordingButton.disabled = false;
+
+                    startRecording();
+                }, false);
+                stopRecordingButton.addEventListener("click", (e) => {
+                    downloadAudioLink.style.display = "block";
+                    startRecordingButton.disabled = false;
+                    stopRecordingButton.disabled = true;
+                    
+                    stopRecording();
+                }, false);
             };
             reader.readAsArrayBuffer(modelFiles[0]);
         };
@@ -52,8 +106,84 @@
             reader.readAsArrayBuffer(scorerFile);
         };
 
+        function startRecording() {
+            activeModelStream = activeModel.createStream();
+            
+            const modelSampleRate = activeModel.getSampleRate();
+            // Create an audio context for future processing.
+            audioContext = new AudioContext({
+                // Use the model's sample rate so that the decoder will resample for us.
+                sampleRate: modelSampleRate
+            });
+            
+            const onSuccess = (stream) => {
+                console.log('started recording');
+                activeRecordingData = [];
+                mediaStream = stream;
+                mediaStreamSource = audioContext.createMediaStreamSource(mediaStream);
+                createAudioProcessor();
+                mediaStreamSource.connect(audioProcessor);
+            };
+            
+            const onError = (error) => {
+                console.error('recording failure', error);
+            };
+            
+            if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+                navigator.mediaDevices.getUserMedia({
+                    video: false,
+                    audio: true
+                })
+                .then(onSuccess)
+                .catch(onError);
+            }
+            else {
+                navigator.getUserMedia({
+                    video: false,
+                    audio: true
+                }, onSuccess, onError);
+            }
+        };
+	
+        function stopRecording() {
+            const transcription = activeModelStream.finishStream();
+            document.getElementById("result").textContent = transcription;
+            console.log(`Transcription: ${transcription}`);
+
+            const modelSampleRate = activeModel.getSampleRate();
+            // TODO: handle different bit widths and more than one channel?
+            var audioUrl = URL.createObjectURL(
+                new Blob([encodeWAV(activeRecordingData, 1, modelSampleRate, 1, 16)], 
+                {type: "audio/wav"})
+            );
+            var downloadAudioEl = document.getElementById("downloadAudioLink");
+            downloadAudioEl.href = audioUrl;
+
+            activeModelStream = null;
+
+            if (mediaStream) {
+                mediaStream.getTracks()[0].stop();
+            }
+            if (mediaStreamSource) {
+                mediaStreamSource.disconnect();
+            }
+            if (audioProcessor) {
+                audioProcessor.shutdown();
+            }
+            if (audioContext) {
+                audioContext.close();
+            }
+        };
+
         function processAudio(audioFile) {
             console.log(`Loading audio file`, audioFile);
+            
+            const modelSampleRate = activeModel.getSampleRate();
+            // Create an audio context for future processing.
+            audioContext = new AudioContext({
+                // Use the model's sample rate so that the decoder will resample for us.
+                sampleRate: modelSampleRate
+            });
 
             let reader = new FileReader();
             reader.onload = (e) => {
@@ -91,6 +221,8 @@
     </script>
     <script src="build/stt_wasm.js"></script>
     <div>
+        <h3>Model Inputs</h3>
+
         <label for="modelpicker">Coqui TFLite Model file:</label>
         <input type="file" name="modelpicker" id="modelpicker" disabled>
 
@@ -101,11 +233,18 @@
 
         <br />
 
+        <h3>Audio input</h3>
         <label for="audiopicker">Audio sample file:</label>
         <input type="file" name="audiopicker" id="audiopicker" disabled>
 
+        <p>OR</p>
+        <button type="button" id="startRecordingButton" disabled>Start Record</button>
+        <button type="button" id="stopRecordingButton" disabled>Stop Recording</button>
+        <a id="downloadAudioLink" download="audio.wav" style="display: none;">Download audio</a>
+
         <br />
 
+        <h3>Transcription Ouput</h3>
         <label for="result">Transcription:</label>
         <span id="result"></span>
 


### PR DESCRIPTION
Allow using microphone input to test the streaming API. 
Allow exporting the recorded audio to WAV (this may not be required in the final version, but is very useful for debugging purposes for now). To export the recorded audio, set the ENABLE_AUDIO_DOWNLOAD variable to true.
Added wav file exporter from https://github.com/Jam3/audiobuffer-to-wav (see `native_client/wasm/audiobuffer-to-wav/License.md`)
